### PR TITLE
install and make requests module available during package install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,9 +11,6 @@
 from setuptools import setup, find_packages
 from codecs import open
 from os import path
-from zipfile import ZipFile
-from io import BytesIO
-from requests import get
 
 
 here = path.abspath(path.dirname(__file__))
@@ -61,7 +58,12 @@ setup(
         'deprecation',
         'pyproj',
         'pyshp',
+        'requests',
         'shapely',
+    ],
+
+    setup_requires=[
+        'requests',
     ],
 
     python_requires='>=3',
@@ -82,7 +84,13 @@ setup(
     },
 )
 
+
 # Install open-location-code python module
+from zipfile import ZipFile
+from io import BytesIO
+from requests import get
+
+
 r = get('https://github.com/google/open-location-code/archive/68ba7ed4c6e7fae41a0255e4394ba1fa0f8435bb.zip')
 z = ZipFile(BytesIO(r.content))
 z.extract('open-location-code-68ba7ed4c6e7fae41a0255e4394ba1fa0f8435bb/python/openlocationcode.py')


### PR DESCRIPTION
Background - I ran into an issue where a portion of my script was relying on the `requests` Python module. During my own testing, I had the package module installed locally, but on a base installation, the package would not normally be pre-installed.

This PR makes the requests module available during package install.