### PR TITLE
Update pkg resources

### DIFF
--- a/buildingid/__init__.py
+++ b/buildingid/__init__.py
@@ -6,4 +6,4 @@
 #
 # See LICENSE.txt and WARRANTY.txt for details.
 
-__import__("pkg_resources").declare_namespace(__name__)
+

--- a/buildingid/version.py
+++ b/buildingid/version.py
@@ -6,4 +6,4 @@
 #
 # See LICENSE.txt and WARRANTY.txt for details.
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"


### PR DESCRIPTION
Fix deprecation warning

pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.